### PR TITLE
Containerization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Exclude everything but the listed exceptions.
+*
+!.git
+!LICENSE
+!pyproject.toml
+!README.md
+!relay
+!setup.*

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,5 @@
 !LICENSE
 !pyproject.toml
 !README.md
-!relay
+!src
 !setup.*

--- a/.github/workflows/container_build.yml
+++ b/.github/workflows/container_build.yml
@@ -1,0 +1,61 @@
+name: Create and publish a Docker image
+
+# Configure this workflow to run every time a change is pushed to a branch
+# whose name starts with `release/` or any time a tag is created; this workflow
+# is also run any time a GitHub release is created or updated ("unpublish" and
+# deletions do not cause it to run).
+on:
+  push:
+    branches: ['release/**']
+    tags: ['*']
+  release:
+    types: [created, edited, prereleased, published, released]
+
+# Set up the container image specification to be `quay.io/pbench/file-relay`.
+env:
+  REGISTRY: quay.io
+  ORGANIZATION: pbench
+  IMAGE_NAME: file-relay
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    # Set the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_ROBOT_TOKEN }}
+
+      # Extract metadata from the Git reference and the GitHub event.
+      # Subsequent steps can reference the values via `steps.meta.outputs.<key>`.
+      # The `images` value provides the name for the container image which is
+      # used in tags and labels.
+      - name: Extract metadata (tags, labels) from Git for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/${{ env.IMAGE_NAME }}
+
+      # Build the container image based on the Dockerfile and the rest of the
+      # files found in the root of the Git checkout.  If the build succeeds,
+      # the image is pushed to the registry indicated by the tags.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          network: host
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,14 @@
 FROM python:3.9
 LABEL org.opencontainers.image.authors="Pbench Maintainers <pbench@googlegroups.com>"
 
+ENTRYPOINT ["relay"]
 WORKDIR /var/tmp
 
-RUN python3 -m pip install --upgrade pip
-
-# Since we install the relay file in/from /src, we seem to need to include it
-# in the PYTHONPATH.
-# FIXME:  how do we get this to install conventionally so we don't need this definition?
-ENV PYTHONPATH=/src/file-relay/relay/
-
-ENTRYPOINT ["relay"]
+# Make sure the packaging and installation tools are up to date.
+RUN python3 -m pip install --upgrade pip setuptools wheel
 
 # Copy the files from the context area to a source directory; install the
-# dependencies; then install the app.
+# dependencies and the app; and remove the sources.
 COPY . /src/file-relay
-RUN python3 -m pip install -r /src/file-relay/relay/requirements.txt
-RUN python3 -m pip install /src/file-relay
+RUN python3 -m pip install -r /src/file-relay/src/requirements.txt /src/file-relay
+RUN rm -rf /src/file-relay

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.9
+LABEL org.opencontainers.image.authors="Pbench Maintainers <pbench@googlegroups.com>"
+
+WORKDIR /var/tmp
+
+RUN python3 -m pip install --upgrade pip
+
+# Since we install the relay file in/from /src, we seem to need to include it
+# in the PYTHONPATH.
+# FIXME:  how do we get this to install conventionally so we don't need this definition?
+ENV PYTHONPATH=/src/file-relay/relay/
+
+ENTRYPOINT ["relay"]
+
+# Copy the files from the context area to a source directory; install the
+# dependencies; then install the app.
+COPY . /src/file-relay
+RUN python3 -m pip install -r /src/file-relay/relay/requirements.txt
+RUN python3 -m pip install /src/file-relay


### PR DESCRIPTION
This PR adds the capability to build and publish the `file-relay` utility as a container image.

This change provides a `Dockerfile` which builds a container image that executes the `file-relay` utility as its entry point.  The resulting container can be invoked as though it were the `file-relay` utility, with `file-relay` command options specified at the end of the invocation command line.

This change also provides a `.dockerignore` file and a GitHub Actions workflow which causes the container image to built when a commit is pushed to a `release/**` branch, when a tag is created or updated, or when a GitHub release is created or updated.  On successful build, the container image is exported to Quay.io and tagged with the branch name, Git tag, or release tag, as appropriate.

Note that this PR is based on #10, so the commits from that PR and its precursors will show up here until they are merged.

PBENCH-1258