### PR TITLE
Add unit test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run isort
         run: isort --check .
       - name: Run tests and collect coverage
-        run: pytest --junitxml=junit/test-results.xml --cov=relay --cov=tests --cov-report=xml --cov-report=html
+        run: pytest --timeout=300 --junitxml=junit/test-results.xml --cov=relay --cov=tests --cov-report=xml --cov-report=html
       - name: Upload pytest test results
         uses: actions/upload-artifact@v3
         with:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,5 +10,6 @@ pytest>=6.2.5
 pytest-cov>=2.7.1
 pytest-helpers-namespace==2019.1.8
 pytest-mock
+pytest-timeout
 pytest-xdist
 responses


### PR DESCRIPTION
This PR adds timeouts to prevent unit tests from hanging.

This was originally part of #7, but it doesn't really have anything to do with that change; and, since I had to rebase it on top of #8 anyway, I figured I would split it out into it's own PR.  Note that, until #8 is merged, its commit(s) will show up here; so, for this review, only the last commit (so far) should be considered.