### PR TITLE
Make the `--bind` option optional

### DIFF
--- a/src/relay/relay.py
+++ b/src/relay/relay.py
@@ -297,7 +297,9 @@ def delete_file(context: click.Context, file_id: str) -> HTTPResponse:
     return HTTPResponse(status=HTTPStatus.OK, body="Success")
 
 
-@click.command()
+@click.command(
+    epilog="See https://github.com/distributed-system-analysis/file-relay#file-relay for more information."
+)
 @click.option(
     "--server_id",
     prompt=True,
@@ -306,7 +308,6 @@ def delete_file(context: click.Context, file_id: str) -> HTTPResponse:
 )
 @click.option(
     "--bind",
-    prompt=True,
     required=True,
     default=DEFAULT_ADDRESS + ":" + str(DEFAULT_PORT),
     show_default=True,
@@ -328,7 +329,9 @@ def delete_file(context: click.Context, file_id: str) -> HTTPResponse:
 )
 @click.pass_context
 def main(context, server_id, bind, files_directory, debug) -> None:
-    """The main function for the relay micro-server
+    """An ad-hoc web server with a simple RESTful interface for transferring files between two clients
+    \f
+    The main function for the `relay` micro-server
 
     Using the Click support, we parse the command line, extract the
     configuration information, store some of it in the Click context, and start


### PR DESCRIPTION
This PR removes the "prompt" requirement from the `--bind` option configuration, so that, if the option is omitted from the command line, the default value will be silently used, rather than requiring the user to confirm it. 

This was originally part of https://github.com/distributed-system-analysis/file-relay/pull/7, but, while it is important for the effectiveness of that change, it doesn't really have anything to do containerization; and, since I had to rebase it on top of https://github.com/distributed-system-analysis/file-relay/pull/8 anyway, I figured I would split it out into it's own PR. Note that this PR is layered on top of #9, so until it is merged, its commit(s) (and those of #8) will show up here; so, for this review, only the last commit (so far) should be considered.