### PR TITLE
Build containers for pushes to main and only published releases

### DIFF
--- a/.github/workflows/container_build.yml
+++ b/.github/workflows/container_build.yml
@@ -1,15 +1,15 @@
 name: Create and publish a Docker image
 
-# Configure this workflow to run every time a change is pushed to a branch
-# whose name starts with `release/` or any time a tag is created; this workflow
-# is also run any time a GitHub release is created or updated ("unpublish" and
-# deletions do not cause it to run).
+# Configure this workflow to run every time a change is pushed to the main
+# branch or any branch whose name starts with `release/` or any time a tag is
+# created; this workflow is also run any time a GitHub release is published.
+# The image will be given a tag which is based on the trigger.
 on:
   push:
-    branches: ['release/**']
+    branches: [main, 'release/**']
     tags: ['*']
   release:
-    types: [created, edited, prereleased, published, released]
+    types: [published]
 
 # Set up the container image specification to be `quay.io/pbench/file-relay`.
 env:


### PR DESCRIPTION
Given that the Action for building containers is fairly intelligent about how it tags them, there is no reason not to build and publish containers for pushes to the `main` branch.  Also, creating a single release goes through four different states, and there is no reason to trigger a container build on every one of them for a single release.

So, this PR adds `main` to the list of branches for which we build containers and it pares the list of release states down to just `published`.