### PR TITLE
Remove files list from status info; update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,8 @@ This utility currently offers five methods:
 - `GET /<server_id>`: return server status
 - `DELETE /<server_id>`: request server shutdown
 
-There are a number of tweaks which are expected to be added:
-- The hash algorithm for resource names may be changed or made configurable
-- The underlying web server may be changed from the reference one to Gunicorn or other
-- The web server should be made able to accept SSL connections
-- The utility needs to be packaged, either as a Python package or a container (or both)
-- Figure out what the server status response _should_ contain -- currently, it provides
-a list of the available files, which undermines the "ya gotta know it's there" story.
-
+There are a number of tweaks which should be considered:
+- Change the hash algorithm for resource names or make it configurable
+- Change the underlying web server from the reference one to Gunicorn or other
+- Make the web server able to accept SSL connections or place it behind a
+suitably-configured proxy inside the container.

--- a/src/relay/relay.py
+++ b/src/relay/relay.py
@@ -6,7 +6,6 @@ import logging
 import os
 from pathlib import Path
 import shutil
-import subprocess
 from typing import Callable
 
 from bottle import Bottle, HTTPResponse, request, static_file
@@ -103,20 +102,10 @@ def relay_status(context: click.Context) -> HTTPResponse:
 
     Returns:
         An HTTP response with a status of OK and a JSON payload containing
-        status information (currently, the output from `ls` listing the files
-        in the upload directory).
+        status information.
     """
     logging.info("request to report status")
     body = {"disk utilization": get_disk_utilization_str(context.meta[CTX_DIRECTORY])}
-
-    cp = subprocess.run(
-        ["ls", "-l"], cwd=context.meta[CTX_DIRECTORY], capture_output=True, text=True
-    )
-    if cp.returncode:
-        body["error"] = cp.stderr.strip()
-    else:
-        body["files"] = cp.stdout.strip().split("\n")
-
     return HTTPResponse(status=HTTPStatus.OK, body=body)
 
 


### PR DESCRIPTION
Now that we're getting ready to deploy this in production, having the current list of files available is a security hazard.  This PR removes that (leaving the disk utilization in the response, because that seems innocuous and even generally useful), and it brings the `README.md` file up to date accordingly.