### PR TITLE
Rev-lock Python to 3.11 in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11.x'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
The version of Flake8 that we use (6.0.0) breaks on Python 3.12.  Rather than upgrade the `flake8` rev-lock (and leave the Python version floating), this change locks the CI's Python version, until we're ready to upgrade it.
